### PR TITLE
Add compatibility shim for pycoin on modern Python

### DIFF
--- a/psbt_faker/__init__.py
+++ b/psbt_faker/__init__.py
@@ -14,6 +14,12 @@ from binascii import a2b_hex
 from io import BytesIO
 from collections import namedtuple
 from base64 import b64encode, b64decode
+import urllib.request
+
+from ._compat import ensure_pycoin_compat
+
+ensure_pycoin_compat()
+
 from pycoin.tx.Tx import Tx
 from pycoin.tx.TxOut import TxOut
 from pycoin.tx.TxIn import TxIn
@@ -22,7 +28,6 @@ from pycoin.encoding import b2a_hashed_base58, hash160
 from pycoin.serialize import b2h_rev, b2h, h2b, h2b_rev
 from pycoin.key.BIP32Node import BIP32Node
 from pycoin.convention import tx_fee
-import urllib.request
 
 from .txn import *
 

--- a/psbt_faker/_compat.py
+++ b/psbt_faker/_compat.py
@@ -1,0 +1,27 @@
+"""Compatibility helpers for legacy dependencies."""
+
+from __future__ import annotations
+
+import inspect
+from collections import namedtuple
+from typing import Any, Callable
+
+
+ArgSpec = namedtuple("ArgSpec", "args varargs keywords defaults")
+
+
+def ensure_pycoin_compat() -> None:
+    """Backport :func:`inspect.getargspec` for older ``pycoin`` releases."""
+
+    if hasattr(inspect, "getargspec"):
+        return
+
+    def _getargspec(func: Callable[..., Any]) -> ArgSpec:  # pragma: no cover - exercised via import
+        spec = inspect.getfullargspec(func)
+        return ArgSpec(spec.args, spec.varargs, spec.varkw, spec.defaults)
+
+    inspect.getargspec = _getargspec  # type: ignore[attr-defined]
+
+
+__all__ = ["ensure_pycoin_compat"]
+

--- a/psbt_faker/psbt.py
+++ b/psbt_faker/psbt.py
@@ -8,12 +8,17 @@ from binascii import b2a_hex as _b2a_hex
 from binascii import a2b_hex as _a2b_hex
 from collections import namedtuple
 from base64 import b64encode
+from binascii import b2a_hex, a2b_hex
+from base64 import b64decode
+
+from ._compat import ensure_pycoin_compat
+
+ensure_pycoin_compat()
+
 from pycoin.tx.Tx import Tx
 #from pycoin.tx.TxOut import TxOut
 #from pycoin.encoding import b2a_hashed_base58, a2b_hashed_base58
 from pycoin.tx.script.check_signature import parse_signature_blob
-from binascii import b2a_hex, a2b_hex
-from base64 import b64decode
 
 b2a_hex = lambda a: str(_b2a_hex(a), 'ascii')
 

--- a/psbt_faker/txn.py
+++ b/psbt_faker/txn.py
@@ -6,6 +6,11 @@ from binascii import b2a_hex, a2b_hex
 from io import BytesIO
 from pprint import pprint, pformat
 from decimal import Decimal
+
+from ._compat import ensure_pycoin_compat
+
+ensure_pycoin_compat()
+
 from pycoin.key.BIP32Node import BIP32Node
 from .psbt import BasicPSBT, BasicPSBTInput, BasicPSBTOutput, PSBT_IN_REDEEM_SCRIPT
 


### PR DESCRIPTION
## Summary
- add a small compatibility helper that restores `inspect.getargspec` when the attribute is missing
- ensure psbt helpers import the shim before importing `pycoin` so Python 3.11+ can run the CLI again

## Testing
- python - <<'PY'
from click.testing import CliRunner
from psbt_faker import faker

runner = CliRunner()
result = runner.invoke(faker, ["/tmp/out.psbt"])
print("exit", result.exit_code)
print(result.output)
PY

------
https://chatgpt.com/codex/tasks/task_e_68cb2d3660e0832292def067eabf1602